### PR TITLE
Add `Route.TrackHTTPMetrics`

### DIFF
--- a/pkg/requestlog/route.go
+++ b/pkg/requestlog/route.go
@@ -15,6 +15,8 @@ type Route struct {
 	TrackHTTPResponseTime func(string) func(int)
 	MetricsEndpoint       string
 
+	TrackHTTPMetrics func(*Route) func(int)
+
 	LogContent bool
 }
 
@@ -22,8 +24,12 @@ var _ http.Handler = (*Route)(nil)
 
 func (rt *Route) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	crw := w.(*CountingResponseWriter)
+	// TODO: replace TrackHTTPResponseTime w/TrackHTTPMetrics
 	if rt.TrackHTTPResponseTime != nil {
 		defer rt.TrackHTTPResponseTime(rt.MetricsEndpoint)(crw.StatusCode)
+	}
+	if rt.TrackHTTPMetrics != nil {
+		defer rt.TrackHTTPMetrics(rt)(crw.StatusCode)
 	}
 	if rt.LogContent {
 		if r.Method != http.MethodGet && r.Method != http.MethodHead {

--- a/pkg/requestlog/route.go
+++ b/pkg/requestlog/route.go
@@ -12,6 +12,8 @@ type Route struct {
 	Method  string
 	Handler http.HandlerFunc
 
+	// Deprecated: both TrackHTTPResponseTime and MetricsEndpoint are replaced
+	// by the TrackHTTPMetrics function which offers increased flexibility.
 	TrackHTTPResponseTime func(string) func(int)
 	MetricsEndpoint       string
 
@@ -24,7 +26,6 @@ var _ http.Handler = (*Route)(nil)
 
 func (rt *Route) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	crw := w.(*CountingResponseWriter)
-	// TODO: replace TrackHTTPResponseTime w/TrackHTTPMetrics
 	if rt.TrackHTTPResponseTime != nil {
 		defer rt.TrackHTTPResponseTime(rt.MetricsEndpoint)(crw.StatusCode)
 	}


### PR DESCRIPTION
Usually this is desired because we'd use the path and method as separate Prometheus labels. Passing the route around allows downstream apps to follow our internal metric standards whilst being flexible for external usage.